### PR TITLE
Add minimal template - Github pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+remote_theme: pages-themes/minimal@v0.2.0
+plugins:
+- jekyll-remote-theme # add this line to the plugins list if you already have one


### PR DESCRIPTION
- We need to set the github pages directory of deploy to be the root of our repository. 

After that, the minimal theme will be applied to the README.md (that will be our documentation web site).